### PR TITLE
docs: add info about "passive" option and "testplane.also.in" helper

### DIFF
--- a/docs/config/browsers.mdx
+++ b/docs/config/browsers.mdx
@@ -249,6 +249,7 @@ windowSize: {
 <tr><td>[retry](#retry)</td><td>Number</td><td>0</td><td>Сколько раз нужно перезапускать падающий тест.</td></tr>
 <tr><td>[shouldRetry](#should_retry)</td><td>Function</td><td>_см. описание_</td><td>Функция, которая определяет нужен ли ретрай. По умолчанию задается функция, которая возвращает _true_, если _retry > 0,_ и _false_, если _retry == 0_.</td></tr>
 <tr><td>[strictTestsOrder](#strict_test_order)</td><td>Boolean</td><td>false</td><td>Гарантировать строгий порядок тестов. Если _true_, то функция API _testplane.readTests_ будет всегда возвращать один и тот же результат.</td></tr>
+<tr><td>[passive](#passive)</td><td>Boolean</td><td>false</td><td>Позволяет сделать браузер пассивным. В пассивных браузерах тесты не запускаются по умолчанию. _Доступна с testplane@8.16.0_.</td></tr>
 
 </tbody>
 </table>
@@ -290,6 +291,17 @@ windowSize: {
 ### strictTestsOrder {#strict_test_order}
 
 Данная опция включает гарантию строгого порядка чтения тестов. По умолчанию: `false`.
+
+### passive {#passive}
+
+<Admonition type="warning">
+    Доступна с testplane@8.16.0. Не работает вместе с устаревшим плагином
+    [hermione-passive-browsers](https://github.com/gemini-testing/testplane-passive-browsers).
+</Admonition>
+
+Позволяет сделать браузер пассивным. В пассивных браузерах тесты не запускаются по умолчанию. С помощью хелпера [testplane.also.in][testplane-also-in-helper] можно включить тест или сьют, перед которым он указан.
+
+По умолчанию: `false`.
 
 ## Информация о тесте и падении {#info_when_test_fails}
 
@@ -652,3 +664,4 @@ RequestOptions => RequestOptions;
 [system-mocha-opts]: ../system#mocha_opts
 [element-wait-until]: ../../commands/element/waitUntil
 [how-to-use-cdp]: ../../guides/how-to-use-cdp
+[testplane-also-in-helper]: ../../guides/how-to-skip-test-in-browsers#solution_4

--- a/docs/guides/how-to-skip-test-in-browsers.mdx
+++ b/docs/guides/how-to-skip-test-in-browsers.mdx
@@ -62,9 +62,20 @@ testplane.only.in("chrome"); // запустить тест только в chro
 testplane.only.notIn("ie8"); // запустить тест во всех браузерах, кроме ie8
 ```
 
+## Решение 4: директива .also.in и браузерная опция passive {#solution_4}
+
+В случае если вы внедряете новый браузер и вам необходимо его запускать только в нескольких тестах, а у вас их тысячи, то использовать хелпер `.skip.in` неудобно. Для решения этой проблемы можно воспользоваться браузерной опцией [passive][passive-option] и хелпером `.also.in`:
+
+```javascript
+testplane.also.in("ie8"); // запустить тест в пассивном браузере ie8
+```
+
 ## Ключевые слова {#keywords}
 
 -   testplane.skip.in
 -   testplane.skip.notIn
 -   testplane.only.in
 -   testplane.only.notIn
+-   testplane.also.in
+
+[passive-option]: ../../config/browsers#passive

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -49,7 +49,7 @@
 -   [по совпадению с маской][testplane-option-grep];
 -   [из конкретного файла][how-to-run-test-in-file];
 -   [заданное количество раз для проверки стабильности][how-to-check-test-stability];
--   [хелперы only.in, only.notIn, skip.in, skip.notIn][how-to-skip-tests].
+-   [хелперы only.in, only.notIn, skip.in, skip.notIn, also.in][how-to-skip-tests].
 
 ### Умное поведение при ошибках {#smart}
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/index.mdx
@@ -51,7 +51,7 @@ And that’s not all.
 -   [by matching patterns][testplane-option-grep];
 -   [from a specific file][how-to-run-test-in-file];
 -   [a set number of times to check stability][how-to-check-test-stability];
--   [helpers only.in, only.notIn, skip.in, skip.notIn][how-to-skip-tests].
+-   [helpers only.in, only.notIn, skip.in, skip.notIn, also.in][how-to-skip-tests].
 
 ### Smart Error Handling {#smart}
 


### PR DESCRIPTION
### What is done

- describe new option browser `passive` and helper `testplane.also.in`. Both were published in testplane@8.16.0