### PR TITLE
fix typo visual-testing-with-storybook.mdx

### DIFF
--- a/docs/basic-guides/visual-testing-with-storybook.mdx
+++ b/docs/basic-guides/visual-testing-with-storybook.mdx
@@ -43,7 +43,7 @@ export default {
 
 ### Step 3: Run tests
 
-To run storybook tests, add the '--storybook` option. The '--update-refs` option allows you to save/update reference images via the CLI:
+To run storybook tests, add the `--storybook` option. The `--update-refs` option allows you to save/update reference images via the CLI:
 
 ```bash
 npx testplane --storybook --update-refs


### PR DESCRIPTION
This pull request makes a small documentation correction to improve the formatting of command-line options in the Storybook visual testing guide.

* Fixed formatting of command-line options by enclosing `--storybook` and `--update-refs` in backticks in `docs/basic-guides/visual-testing-with-storybook.mdx`.